### PR TITLE
 API can provide products sorted in categories

### DIFF
--- a/app/controllers/api/products_controller.rb
+++ b/app/controllers/api/products_controller.rb
@@ -6,7 +6,6 @@ class Api::ProductsController < ApplicationController
     else
       render json: { message: 'There are no products in the database.' }, status: 422
     end
-    
   end
 end
 

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,3 +1,3 @@
 class Product < ApplicationRecord
-  validates_presence_of :name, :price
+  validates_presence_of :name, :price, :category
 end

--- a/db/migrate/20220216112234_add_category_to_product.rb
+++ b/db/migrate/20220216112234_add_category_to_product.rb
@@ -1,0 +1,5 @@
+class AddCategoryToProduct < ActiveRecord::Migration[6.0]
+  def change
+    add_column :products, :category, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,7 +16,7 @@ ActiveRecord::Schema.define(version: 2022_02_16_112234) do
   enable_extension "plpgsql"
 
   create_table "products", force: :cascade do |t|
-    t.string "title"
+    t.string "name"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.text "price"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,16 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_11_084621) do
+ActiveRecord::Schema.define(version: 2022_02_16_112234) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "products", force: :cascade do |t|
-    t.string "name"
+    t.string "title"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.text "price"
+    t.text "category"
   end
 
 end

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -2,5 +2,6 @@ FactoryBot.define do
   factory :product do
     name { "chicken wings" }
     price { "200 kr" }
+    category { "starter"}
   end
 end

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -4,10 +4,15 @@ RSpec.describe Product, type: :model do
   describe 'DB table' do
     it {is_expected.to have_db_column :name }
     it {is_expected.to have_db_column :price}
+    it {is_expected.to have_db_column :category}
+
   end
   describe 'Validations' do
     it {is_expected.to validate_presence_of :name }
     it {is_expected.to validate_presence_of :price}
+    it {is_expected.to validate_presence_of :category}
+
+
   end
   describe 'Factory' do
     it 'should have valid Factory' do

--- a/spec/requests/api/api_responds_with_a_collection_of_product_spec.rb
+++ b/spec/requests/api/api_responds_with_a_collection_of_product_spec.rb
@@ -16,6 +16,11 @@ RSpec.describe 'GET /api/products' do
     it 'is expected to return products names' do
       expect(response_json['products'].first['name']).to eq 'chicken wings'
     end
+
+    it 'is expected to return a category' do
+      expect(response_json['products'].first['category']).to eq 'starter'
+    end
+    
   end
   describe 'unsuccessfully' do
     describe 'when there are no products in the database' do


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/181106873

As a restaurant API
In order to give the client better-sorted products
I would like to be able to send off the products in categories of starter, main, and sides
<img width="831" alt="Screenshot 2022-02-16 at 21 45 58" src="https://user-images.githubusercontent.com/54026570/154355298-c523d643-1512-4393-820c-d5b30d1bafb6.png">
<img width="601" alt="Screenshot 2022-02-16 at 21 55 09" src="https://user-images.githubusercontent.com/54026570/154355405-8a350e76-9ef4-481a-a1f9-bf06c137334c.png">
.